### PR TITLE
Shutdown and resolved events

### DIFF
--- a/lib/backbeat/errors.rb
+++ b/lib/backbeat/errors.rb
@@ -30,6 +30,7 @@
 
 module Backbeat
   class InvalidStatusChange < StandardError; end
+  class UnknownStatus < StandardError; end
   class InvalidServerStatusChange < InvalidStatusChange; end
   class InvalidClientStatusChange < InvalidStatusChange
     attr_reader :data

--- a/lib/backbeat/events.rb
+++ b/lib/backbeat/events.rb
@@ -187,6 +187,16 @@ module Backbeat
       end
     end
 
+    class ShutdownNode < Event
+      scheduler Schedulers::PerformEvent
+
+      def call(node)
+        node.parent.children.each do |child|
+          StateManager.transition(child, current_server_status: :deactivated) if child.seq >= node.seq
+        end
+      end
+    end
+
     class CancelNode < Event
       scheduler Schedulers::PerformEvent
 

--- a/lib/backbeat/events.rb
+++ b/lib/backbeat/events.rb
@@ -113,6 +113,19 @@ module Backbeat
       end
     end
 
+    class ClientResolved < Event
+      include ResponseHandler
+      scheduler Schedulers::PerformEvent
+
+      def call(node)
+        StateManager.new(node, response).with_rollback do |state|
+          state.transition(current_client_status: :resolved, current_server_status: :processing_children)
+          node.mark_complete!
+          Server.fire_event(MarkChildrenReady, node)
+        end
+      end
+    end
+
     class NodeComplete < Event
       scheduler Schedulers::PerformEvent
 

--- a/lib/backbeat/models/node.rb
+++ b/lib/backbeat/models/node.rb
@@ -75,6 +75,7 @@ module Backbeat
                                            :received,
                                            :processing,
                                            :complete,
+                                           :resolved,
                                            :errored]
 
     delegate :retries_remaining, :retry_interval, :legacy_type, :legacy_type=, to: :node_detail

--- a/lib/backbeat/models/node.rb
+++ b/lib/backbeat/models/node.rb
@@ -75,8 +75,9 @@ module Backbeat
                                            :received,
                                            :processing,
                                            :complete,
+                                           :errored,
                                            :resolved,
-                                           :errored]
+                                           :shutdown]
 
     delegate :retries_remaining, :retry_interval, :legacy_type, :legacy_type=, to: :node_detail
     delegate :data, to: :client_node_detail, prefix: :client

--- a/lib/backbeat/state_manager.rb
+++ b/lib/backbeat/state_manager.rb
@@ -37,7 +37,7 @@ module Backbeat
         ready: [:received, :errored],
         received: [:processing, :complete, :errored],
         processing: [:complete, :errored],
-        errored: [:ready, :errored, :resolved],
+        errored: [:ready, :errored, :resolved, :shutdown],
         complete: [:complete]
       },
       current_server_status: {

--- a/lib/backbeat/state_manager.rb
+++ b/lib/backbeat/state_manager.rb
@@ -37,7 +37,7 @@ module Backbeat
         ready: [:received, :errored],
         received: [:processing, :complete, :errored],
         processing: [:complete, :errored],
-        errored: [:ready, :errored],
+        errored: [:ready, :errored, :resolved],
         complete: [:complete]
       },
       current_server_status: {
@@ -50,7 +50,7 @@ module Backbeat
         paused: [:started, :deactivated, :errored],
         errored: [:ready, :deactivated, :errored],
         retrying: [:ready, :deactivated, :errored],
-        retries_exhausted: [:ready, :deactivated, :errored],
+        retries_exhausted: [:ready, :deactivated, :errored, :processing_children],
         deactivated: [:deactivated]
       }
     }

--- a/lib/backbeat/web.rb
+++ b/lib/backbeat/web.rb
@@ -81,6 +81,10 @@ module Backbeat
         error!(ErrorPresenter.present(e), 409)
       end
 
+      rescue_from UnknownStatus do |e|
+        error!(ErrorPresenter.present(e), 400)
+      end
+
       mount WorkflowsAPI.versioned('/')
       mount ActivitiesAPI.versioned('/activities')
       mount UsersAPI

--- a/lib/backbeat/web/activities_api.rb
+++ b/lib/backbeat/web/activities_api.rb
@@ -101,7 +101,9 @@ module Backbeat
           node = find_node
           node.touch!
           new_status = params[:new_status].to_sym
-          event_type = CLIENT_EVENTS[new_status]
+          event_type = CLIENT_EVENTS.fetch(new_status) do
+            raise UnknownStatus, "Unknown status change #{new_status}"
+          end
           response = params[:response] || params[:args]
           event = response ? event_type.new(response) : event_type
           Server.fire_event(event, node)

--- a/lib/backbeat/web/activities_api.rb
+++ b/lib/backbeat/web/activities_api.rb
@@ -40,12 +40,13 @@ module Backbeat
     class ActivitiesAPI < VersionedAPI
 
       CLIENT_EVENTS = {
-        deciding: Events::ClientProcessing,
+        deciding: Events::ClientProcessing, # Legacy status
         processing: Events::ClientProcessing,
-        deciding_complete: Events::ClientComplete,
+        deciding_complete: Events::ClientComplete, # Legacy status
         completed: Events::ClientComplete,
         errored: Events::ClientError,
         resolved: Events::ClientResolved,
+        shutdown: Events::ShutdownNode,
         deactivated: Events::DeactivatePreviousNodes,
         canceled: Events::CancelNode
       }
@@ -111,12 +112,6 @@ module Backbeat
           node = find_node
           node.touch!
           Server.fire_event(Events::ScheduleNextNode, node)
-        end
-
-        put "/:id/shutdown" do
-          node = find_node
-          node.touch!
-          Server.fire_event(Events::ShutdownNode, node)
         end
 
         put "/:id/restart" do

--- a/lib/backbeat/web/activities_api.rb
+++ b/lib/backbeat/web/activities_api.rb
@@ -106,6 +106,18 @@ module Backbeat
           { success: true }
         end
 
+        put "/:id/schedule" do
+          node = find_node
+          node.touch!
+          Server.fire_event(Events::ScheduleNextNode, node)
+        end
+
+        put "/:id/shutdown" do
+          node = find_node
+          node.touch!
+          Server.fire_event(Events::ShutdownNode, node)
+        end
+
         put "/:id/restart" do
           node = find_node
           Workers::AsyncWorker.remove_job(Events::RetryNode, node)

--- a/lib/backbeat/web/activities_api.rb
+++ b/lib/backbeat/web/activities_api.rb
@@ -45,6 +45,7 @@ module Backbeat
         deciding_complete: Events::ClientComplete,
         completed: Events::ClientComplete,
         errored: Events::ClientError,
+        resolved: Events::ClientResolved,
         deactivated: Events::DeactivatePreviousNodes,
         canceled: Events::CancelNode
       }

--- a/spec/integration/web/activities_api_spec.rb
+++ b/spec/integration/web/activities_api_spec.rb
@@ -383,6 +383,23 @@ describe Backbeat::Web::ActivitiesAPI, :api_test do
       end
     end
 
+    context "PUT /#{path}/:id/status/resolved" do
+      it "marks the node as complete" do
+        node.update_attributes({
+          current_server_status: :retries_exhausted,
+          current_client_status: :errored
+        })
+        client_params = { "result" => "Done", "error" => nil }
+
+        put "#{path}/#{node.id}/status/resolved", { "response" => client_params }
+        node.reload
+
+        expect(node.current_client_status).to eq("resolved")
+        expect(node.current_server_status).to eq("processing_children")
+        expect(node.status_changes.last.response).to eq(client_params)
+      end
+    end
+
     context "PUT #{path}/:id/reset" do
       it "deactivates all child nodes on the node" do
         child = FactoryGirl.create(:node, user: user, workflow: workflow, parent: node)

--- a/spec/integration/web/activities_api_spec.rb
+++ b/spec/integration/web/activities_api_spec.rb
@@ -308,6 +308,14 @@ describe Backbeat::Web::ActivitiesAPI, :api_test do
       end
     end
 
+    context "PUT /#{path}/:id/status" do
+      it "returns 400 for an unknown status change" do
+        response = put "#{path}/#{node.id}/status/done"
+
+        expect(response.status).to eq(400)
+      end
+    end
+
     context "PUT /#{path}/:id/status/processing" do
       it "fires the ClientProcessing event" do
         node.update_attributes(current_client_status: :received)


### PR DESCRIPTION
Adds two transitions:

1) shutdown
- marks the client status as shutdown
- deactivates any dependent siblings
- schedules any child activities used to clean up state

2) resolved
- marks the client status as resolved
- schedules any child activities