### PR TITLE
Allows client to specify time ranges in activity report. Defaults to …

### DIFF
--- a/config/defaults/options.yml
+++ b/config/defaults/options.yml
@@ -11,3 +11,5 @@ defaults:
     heal_nodes: '0 */2 * * * *'
     daily_activity: '0 12 * * * *'
     log_queues: '0 */5 * * * *'
+  reporting:
+    intervals: ~


### PR DESCRIPTION
…previous behavior.

This pull request adds the ability to supply different relative cutoff times (in sec) for the daily activity report. The use case for this feature comes from a client which would consider incomplete nodes 3 or more hours old to be inconsistent, and the hardcoded 12 hours was not providing an accurate view of the system. When no options are supplied the report uses the times previously hardcoded.