### PR TITLE
New Exponential Backoff

### DIFF
--- a/lib/backbeat/models/node_detail.rb
+++ b/lib/backbeat/models/node_detail.rb
@@ -37,7 +37,7 @@ module Backbeat
     serialize :valid_next_events, JSON
 
     before_validation do
-      self.retries_remaining ||= 4
+      self.retries_remaining ||= 6
       self.retry_interval ||= 20.minutes
     end
   end

--- a/spec/integration/workflows/retry_node_spec.rb
+++ b/spec/integration/workflows/retry_node_spec.rb
@@ -54,7 +54,7 @@ describe Backbeat, :api_test do
         "current_client_status" => "received",
         "current_server_status" => "sent_to_client"
       )
-      expect(activity_node.node_detail.retries_remaining).to eq(4)
+      expect(activity_node.node_detail.retries_remaining).to eq(6)
 
       response = put "activities/#{activity_node.id}/status/errored"
 
@@ -64,7 +64,7 @@ describe Backbeat, :api_test do
         "current_client_status" => "received",
         "current_server_status" => "sent_to_client"
       )
-      expect(activity_node.node_detail.retries_remaining).to eq(3)
+      expect(activity_node.node_detail.retries_remaining).to eq(5)
 
       response = put "activities/#{activity_node.id}/status/completed"
       expect(activity_node.reload.attributes).to include(

--- a/spec/unit/events_spec.rb
+++ b/spec/unit/events_spec.rb
@@ -361,7 +361,7 @@ describe Backbeat::Events do
       it "decrements the retry count" do
         Backbeat::Events::ClientError.call(node)
 
-        expect(node.node_detail.retries_remaining).to eq(3)
+        expect(node.node_detail.retries_remaining).to eq(5)
       end
 
       it "marks the server status as retrying" do

--- a/spec/unit/models/node_spec.rb
+++ b/spec/unit/models/node_spec.rb
@@ -73,11 +73,11 @@ describe Backbeat::Node do
 
   context "mark_retried!" do
     it "decrements the retries remaining" do
-      expect(node.retries_remaining).to eq(4)
+      expect(node.retries_remaining).to eq(6)
 
       node.mark_retried!
 
-      expect(node.reload.retries_remaining).to eq(3)
+      expect(node.reload.retries_remaining).to eq(5)
     end
   end
 

--- a/spec/unit/schedulers_spec.rb
+++ b/spec/unit/schedulers_spec.rb
@@ -79,42 +79,46 @@ describe Backbeat::Schedulers do
     let(:now) { Time.now }
 
     retries = [
-      { retries_remaining: 51, lower_bound: 0.minutes, upper_bound: 30.minutes },
-      { retries_remaining: 4, lower_bound: 0.minutes, upper_bound: 30.minutes },
-      { retries_remaining: 1, lower_bound: 81.minutes, upper_bound: 201.minutes }
+      { retries_remaining: 51, lower_bound: 16.minutes, upper_bound: 24.minutes },
+      { retries_remaining: 6, lower_bound: 16.minutes, upper_bound: 24.minutes },
+      { retries_remaining: 4, lower_bound: 64.minutes, upper_bound: 96.minutes },
+      { retries_remaining: 2, lower_bound: 256.minutes, upper_bound: 384.minutes },
+      { retries_remaining: 0, lower_bound: 1024.minutes, upper_bound: 1536.minutes }
     ]
 
     retries.each do |params|
-      it "calculates retry interval by progressively backing off as remaining retries decrease from 4" do
-        node.node_detail.update_attributes({
-          retries_remaining: params[:retries_remaining],
-          retry_interval: 20.minutes
-        })
+      describe params do
+        it "calculates retry interval by progressively backing off as remaining retries decrease from 4" do
+          node.node_detail.update_attributes({
+            retries_remaining: params[:retries_remaining],
+            retry_interval: 20.minutes
+          })
 
-        expect(Backbeat::Workers::AsyncWorker).to receive(:schedule_async_event) do |event, evented_node, args|
-          expect(event).to eq(MockEvent)
-          expect(evented_node).to eq(node)
+          expect(Backbeat::Workers::AsyncWorker).to receive(:schedule_async_event) do |event, evented_node, args|
+            expect(event).to eq(MockEvent)
+            expect(evented_node).to eq(node)
 
-          time = args[:time]
+            time = args[:time]
 
-          expect(time).to be >= now + node.retry_interval + params[:lower_bound]
-          expect(time).to be <= now + node.retry_interval + params[:upper_bound]
+            expect(time).to be >= now + params[:lower_bound]
+            expect(time).to be <= now + params[:upper_bound]
+          end
+
+          Backbeat::Schedulers::ScheduleRetry.call(MockEvent, node)
         end
 
-        Backbeat::Schedulers::ScheduleRetry.call(MockEvent, node)
-      end
+        it "updates the node's fires_at time" do
+          node.node_detail.update_attributes({
+            retries_remaining: params[:retries_remaining],
+            retry_interval: 20.minutes
+          })
 
-      it "updates the node's fires_at time" do
-        node.node_detail.update_attributes({
-          retries_remaining: params[:retries_remaining],
-          retry_interval: 20.minutes
-        })
+          Backbeat::Schedulers::ScheduleRetry.call(MockEvent, node)
+          time = node.fires_at
 
-        Backbeat::Schedulers::ScheduleRetry.call(MockEvent, node)
-        time = node.fires_at
-
-        expect(time).to be >= now + node.retry_interval + params[:lower_bound]
-        expect(time).to be <= now + node.retry_interval + params[:upper_bound]
+          expect(time).to be >= now + params[:lower_bound]
+          expect(time).to be <= now + params[:upper_bound]
+        end
       end
     end
   end


### PR DESCRIPTION
https://github.com/groupon/backbeat/blob/master/lib/backbeat/schedulers.rb#L51

It's currently impossible to set up an activity to retry "soon" with any reliability.

```ruby
      tries = DEFAULT_RETRIES - node.retries_remaining
      tries = 0 if tries < 0
      interval_seconds = node.retry_interval
      padding_minutes = tries ** 4 + rand(0..30) * (tries + 1)
      backoff_seconds = padding_minutes * 60 + interval_seconds
      time = Time.now + backoff_seconds
      node.update_attributes(fires_at: Time.now)
```
This algorithm is devastating to end-user controllability. Even if I set my retry_interval to 1 (second) it still happens between 1 second and 31m1s.

I did some research and experimentation and rewrote the scheduling algorithm, trying to maintain the linear->exponential transition and the needs outlined in the spec.

Unfortunately, the countdown retries style makes specification of an Activity with few retries problematic, but I don't see a simple way to resolve that without adding more state information to the Node table, or changing the API entirely.

```ruby
EXPONENTIAL_THRESHOLD = 6

    ScheduleRetry = AsyncEvent.new do |node|
      exponent = EXPONENTIAL_THRESHOLD - node.retries_remaining
      exponent = 0 if exponent < 0

      time = Time.now + (rand(0.8..1.2) * node.retry_interval) * (2**exponent)
      node.update_attributes(fires_at: time)
      time
    end
```

But with this, if you want to retry in 20 minute intervals you can. When your retries remaining drops below 6, it will start to exponentiate. The ceiling at the last retry is 25 hours. So setting up an Activity with a similar retry interval will enable that activity to recover by retrying after an outage lasting longer than 1 day.

The retry scheduling is far more predictable, and still has some stampede-reduction properties thanks to a very narrow random multiplier factor.

The bonus is that if you want an activity to retry every 5 seconds for 3 hours, and then exponentiate, you can. Simply set the interval to 5 seconds and the retries_remaining to 2160. Or if you just want a test activity that retries once immediately, set the retry_interval to 0. Setting it to 1 gives you a retry somewhere within 50s-76s, which is a downside of having such a high exponent for the last retry.