### PR TITLE
We don't support God option for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ $ bin/docker_console
   - [Install on Linux](http://redis.io/topics/quickstart)
 12. Start Web Server and Workers
   - For testing you can run these as daemons or in different terminal windows
-  - For production you will want to use some sort of monitoring on these processes. We provide an option using God as explained [here]().
+  - For production you will want to use some sort of monitoring on these processes.
   - See the Procfile for a summary of the processes
 
   ```bash


### PR DESCRIPTION
The link is empty, and actually we support God only if using `capistrano-backbeat`.

Since capistrano-backbeat isn't open-sourced yet, we don't support God option for now.

Also, this wiki page needs to be updated since it also mentions capistrano-backbeat.

cc @nchainani 