### PR TITLE
Support more ruby versions in travis

### DIFF
--- a/.ci.yml
+++ b/.ci.yml
@@ -1,6 +1,0 @@
-run:
-  ci:
-<% if( DOTCI_BRANCH =~ /deploy.*/) { %>
-plugins:
-  - publish: 'ci'
-<% } %>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
-sudo: required
+sudo: false
 
 language: ruby
+
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1.6
+  - jruby-1.7.20
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: ruby
 rvm:
   - 2.0.0
   - 2.1.6
+  - 2.2.3
+  - 2.3.0
   - jruby-1.7.20
 
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: ruby
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.6
   - jruby-1.7.20

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ bin/docker_console
 
 3. Install any of the supported Ruby versions:
   - JRuby 1.7.3 - 1.7.20
-  - MRI 2.0.0 - 2.1.6
+  - MRI 2.0.0 - 2.3.0
 
 4. Install [Bundler](http://gembundler.com/) if necessary:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ bin/docker_console
 
 3. Install any of the supported Ruby versions:
   - JRuby 1.7.3 - 1.7.20
-  - MRI 1.9.3 - 2.1.6
+  - MRI 2.0.0 - 2.1.6
 
 4. Install [Bundler](http://gembundler.com/) if necessary:
 

--- a/spec/unit/workers/daily_activity_spec.rb
+++ b/spec/unit/workers/daily_activity_spec.rb
@@ -72,28 +72,30 @@ describe Backbeat::Workers::DailyActivity do
       allow(Backbeat::Config).to receive(:hostname).and_return("somehost")
 
       Timecop.freeze(start_time) do
-        expect(subject).to receive(:send_report).with({
-          inconsistent: {
-            counts: {
-              "bad workflow" => { workflow_type_count: 1, node_count: 1 }
+        expect(subject).to receive(:send_report) do |arg|
+          arg == {
+            inconsistent: {
+              counts: {
+                "bad workflow" => { workflow_type_count: 1, node_count: 1 }
+              },
+              filename: "/tmp/inconsistent_nodes/#{Date.today.to_s}.json",
+              hostname: "somehost"
             },
-            filename: "/tmp/inconsistent_nodes/#{Date.today.to_s}.json",
-            hostname: "somehost"
-          },
-          completed: {
-            counts: {
-              "fun workflow"=> { workflow_type_count: 1, node_count: 1 }
-            }
-          },
-          time_elapsed: 0,
-          range: {
-            completed_upper_bound: start_time,
-            completed_lower_bound: start_time - 24.hours,
-            inconsistent_upper_bound: start_time - 12.hours,
-            inconsistent_lower_bound: start_time - 1.year
-           },
-          date: start_time.strftime("%m/%d/%Y")
-        })
+            completed: {
+              counts: {
+                "fun workflow"=> { workflow_type_count: 1, node_count: 1 }
+              }
+            },
+            time_elapsed: 0,
+            range: {
+              completed_upper_bound: start_time,
+              completed_lower_bound: start_time - 24.hours,
+              inconsistent_upper_bound: start_time - 12.hours,
+              inconsistent_lower_bound: start_time - 1.year
+             },
+            date: start_time.strftime("%m/%d/%Y")
+          }
+        end
 
         subject.perform
       end


### PR DESCRIPTION
Serveral changes in this PR:

* Remove MRI 1.9 support since Sidekiq 3.5.3 doesn't support Ruby 1.9
* We support MRI 2.2 and 2.3
* Add all supported ruby versions in travis
* Fix failed spec on MRI: RSpec 3 uses `===` for argument matchers, which will cause argument doesn't match on MRI
* Remove useless .ci.yml