### PR TITLE
speed up /restart endpoint by making one step optional

### DIFF
--- a/lib/backbeat/web/activities_api.rb
+++ b/lib/backbeat/web/activities_api.rb
@@ -118,7 +118,12 @@ module Backbeat
 
         put "/:id/restart" do
           node = find_node
-          Workers::AsyncWorker.remove_job(Events::RetryNode, node)
+
+          unless node.current_server_status == 'retries_exhausted'
+            # remove any async jobs which might auto-retry running this node
+            Workers::AsyncWorker.remove_job(Events::RetryNode, node)
+          end
+
           Server.fire_event(Events::RetryNode, node, Schedulers::PerformEvent)
           { success: true }
         end

--- a/spec/integration/web/activities_api_spec.rb
+++ b/spec/integration/web/activities_api_spec.rb
@@ -193,6 +193,17 @@ describe Backbeat::Web::ActivitiesAPI, :api_test do
 
           put "#{path}/#{node.id}/restart"
         end
+
+        it "skips checking retry jobs if the node status is retries_exhausted" do
+          node.update_attributes!(current_server_status: :retries_exhausted)
+
+          expect(Backbeat::Workers::AsyncWorker).to_not receive(:remove_job).with(
+            Backbeat::Events::RetryNode,
+            node
+          )
+
+          put "#{path}/#{node.id}/restart"
+        end
       end
 
       context "with invalid restart state" do


### PR DESCRIPTION
This is an O(n) operation and based on experience, takes ~30 seconds with 500k jobs in queue. There is no reason to check in the async jobs if the retries have already exhausted (which I believe is the common case someone would want to restart a node)