### PR TITLE
Bug fix for race condition error

### DIFF
--- a/lib/backbeat/state_manager.rb
+++ b/lib/backbeat/state_manager.rb
@@ -107,7 +107,7 @@ module Backbeat
       result = Node.connection.execute(update_sql(statuses))
       rows_affected = result.respond_to?(:cmd_tuples) ? result.cmd_tuples : result # The jruby adapter does not return a PG::Result
       if rows_affected == 0
-        raise StaleStatusChange, "Stale status change data for node #{node.id}"
+        raise Backbeat::StaleStatusChange, "Stale status change data for node #{node.id}"
       else
         create_status_changes(statuses)
         node.reload


### PR DESCRIPTION
The error created in this line was not able to log an error_type because ```StaleStatusChange``` returns uninitialized constant error. Prepending ```Backbeat``` namespace so that these occurrences are not logged as uncaught system errors.

Unit tests for this functionality were stubbing the appropriately namespaced ```Backbeat::StaleStatusChange``` and were therefore not surfacing this bug.