### PR TITLE
Add domain name to the hostname config variable

### DIFF
--- a/lib/backbeat/config.rb
+++ b/lib/backbeat/config.rb
@@ -64,7 +64,7 @@ module Backbeat
     end
 
     def self.hostname
-      @hostname ||= `hostname`
+      @hostname ||= `hostname -f`
     end
 
     def self.revision


### PR DESCRIPTION
This is useful when you are running in different datacenters.