### PR TITLE
Bug fix for error logging.

### DIFF
--- a/lib/backbeat/web.rb
+++ b/lib/backbeat/web.rb
@@ -50,7 +50,7 @@ module Backbeat
       end
 
       rescue_from :all do |e|
-        Logger.error({ error_type: e.class, error: e.message, backtrace: e.backtrace })
+        Logger.error({ error_type: e.class.to_s, error: e.message, backtrace: e.backtrace })
         error!(ErrorPresenter.present(e), 500)
       end
 


### PR DESCRIPTION
The current implementation of error logging always returns empty hash as error type in logs. Casting class to string first will allow this field to be populated properly.