### PR TITLE
make hostname contains colo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ before_script:
   - RACK_ENV=test bundle exec rake db:migrate
 
 script:
+  - mkdir log/ && touch ./log/test.log
   - bundle exec rspec spec

--- a/lib/backbeat/config.rb
+++ b/lib/backbeat/config.rb
@@ -64,7 +64,7 @@ module Backbeat
     end
 
     def self.hostname
-      @hostname ||= `hostname`
+      @hostname ||= `hostname -f`
     end
 
     def self.revision


### PR DESCRIPTION
We're missing colo in `... stored at /tmp/2017-05-08.json on worker1`

This PR will fix it: `... stored at /tmp/2017-05-08.json on worker1.<colo>`