### PR TITLE
Logs activity post error type and message

### DIFF
--- a/lib/backbeat/client.rb
+++ b/lib/backbeat/client.rb
@@ -75,8 +75,8 @@ module Backbeat
           body: params.to_json,
           headers: { "Content-Type" => "application/json" }
         })
-      rescue
-        raise HttpError.new("Could not POST #{url}")
+      rescue => e
+        raise HttpError.new("Could not POST #{url}, error: #{e.class}, #{e.message}")
       end
     end
   end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -168,6 +168,14 @@ describe Backbeat::Client do
 
         expect { Backbeat::Client.perform(node) }.to raise_error(Backbeat::HttpError, "HTTP request for activity failed")
       end
+
+      it "raises an http error if HTTParty fails" do
+        node.legacy_type = :activity
+
+        expect(HTTParty).to receive(:post).and_raise(HTTParty::Error.new("Request failure"))
+
+        expect { Backbeat::Client.perform(node) }.to raise_error(Backbeat::HttpError, "Could not POST http://activity.com/api/v1/workflows/perform_activity, error: HTTParty::Error, Request failure")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is intended to log details of errors raised by HTTParty upon posting to the activity endpoint.