### PR TITLE
add configurable wait time to recover from ECONNRESET error

### DIFF
--- a/config/defaults/options.yml
+++ b/config/defaults/options.yml
@@ -4,6 +4,7 @@ defaults:
   log: ~
   client_timeout: 172800
   require_auth_token: false
+  connection_error_wait: 30
   alerts:
     email_to: ~
     email_from: ~

--- a/lib/backbeat/workers/async_worker.rb
+++ b/lib/backbeat/workers/async_worker.rb
@@ -76,6 +76,11 @@ module Backbeat
       rescue DeserializeError => e
         error(status: :deserialize_node_error, node: node_data["node_id"], error: e, backtrace: e.backtrace)
         raise e
+      rescue Errno::ECONNRESET => e
+        Kernel.sleep(Config.options[:connection_error_wait])
+        if (node.reload.current_client_status != :complete)
+          handle_processing_error(e, event_class, node, options)
+        end
       rescue => e
         handle_processing_error(e, event_class, node, options)
       end


### PR DESCRIPTION
This is to alleviate an error we are having with the network where ECONNRESET hang ups are causing backbeat to get out of sync. By adding a configurable wait time when encountering such errors we give backbeat a chance to catch up and receive a complete message.