### PR TITLE
allow client to rethrow connection reset exception

### DIFF
--- a/lib/backbeat/client.rb
+++ b/lib/backbeat/client.rb
@@ -76,7 +76,7 @@ module Backbeat
           headers: { "Content-Type" => "application/json" }
         })
       rescue => e
-        raise HttpError.new("Could not POST #{url}, error: #{e.class}, #{e.message}")
+        raise NetworkError.new("Could not POST #{url}, error: #{e.class}, #{e.message}")
       end
     end
   end

--- a/lib/backbeat/errors.rb
+++ b/lib/backbeat/errors.rb
@@ -63,4 +63,12 @@ module Backbeat
       super(message)
     end
   end
+
+  class NetworkError < StandardError
+    attr_reader :response
+    def initialize(message, response = nil)
+      @response = response
+      super(message)
+    end
+  end
 end

--- a/lib/backbeat/workers/async_worker.rb
+++ b/lib/backbeat/workers/async_worker.rb
@@ -76,7 +76,7 @@ module Backbeat
       rescue DeserializeError => e
         error(status: :deserialize_node_error, node: node_data["node_id"], error: e, backtrace: e.backtrace)
         raise e
-      rescue Errno::ECONNRESET => e
+      rescue NetworkError => e
         Kernel.sleep(Config.options[:connection_error_wait])
         if (node.reload.current_client_status != :complete)
           handle_processing_error(e, event_class, node, options)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -142,6 +142,17 @@ describe Backbeat::Client do
 
         expect { Backbeat::Client.perform(node) }.to raise_error(Backbeat::HttpError, "HTTP request for decision failed")
       end
+
+      it "raises a network error if the connection is reset" do
+        node.legacy_type = :decision
+
+        WebMock.stub_request(:post, "http://decisions.com/api/v1/workflows/make_decision").with(
+          body: { decision: Backbeat::NodePresenter.present(node) }.to_json,
+          headers: { 'Content-Type'=>'application/json'}
+        ).to_raise(Errno::ECONNRESET)
+
+        expect { Backbeat::Client.perform(node) }.to raise_error(Backbeat::NetworkError)
+      end
     end
 
     context ".perform_activity" do
@@ -169,12 +180,23 @@ describe Backbeat::Client do
         expect { Backbeat::Client.perform(node) }.to raise_error(Backbeat::HttpError, "HTTP request for activity failed")
       end
 
-      it "raises an http error if HTTParty fails" do
+      it "raises a network error if the connection is reset" do
+        node.legacy_type = :activity
+
+        stub = WebMock.stub_request(:post, "http://activity.com/api/v1/workflows/perform_activity").with(
+          :body => { activity: Backbeat::NodePresenter.present(node) }.to_json,
+          :headers => { 'Content-Type'=>'application/json' }
+        ).to_raise(Errno::ECONNRESET)
+
+        expect { Backbeat::Client.perform(node) }.to raise_error(Backbeat::NetworkError)
+      end
+
+      it "raises an network error if HTTParty fails" do
         node.legacy_type = :activity
 
         expect(HTTParty).to receive(:post).and_raise(HTTParty::Error.new("Request failure"))
 
-        expect { Backbeat::Client.perform(node) }.to raise_error(Backbeat::HttpError, "Could not POST http://activity.com/api/v1/workflows/perform_activity, error: HTTParty::Error, Request failure")
+        expect { Backbeat::Client.perform(node) }.to raise_error(Backbeat::NetworkError, "Could not POST http://activity.com/api/v1/workflows/perform_activity, error: HTTParty::Error, Request failure")
       end
     end
   end


### PR DESCRIPTION
The backbeat client will now no longer swallow connection reset errors and wrap them in `HttpError`s. This will allow connection reset errors to be handled differently in async_worker, namely, giving the client a chance to come back with a `complete` message.