### PR TITLE
add network error handling to Events::StartNode

### DIFF
--- a/lib/backbeat/events.rb
+++ b/lib/backbeat/events.rb
@@ -85,6 +85,12 @@ module Backbeat
         else
           Server.fire_event(ClientComplete, node)
         end
+      rescue NetworkError => e
+        Kernel.sleep(Config.options[:connection_error_wait])
+        if (node.reload.current_client_status != :complete)
+          response = { error: { message: e.message } }
+          Server.fire_event(ClientError.new(response), node)
+        end
       rescue HttpError => e
         response = { error: { message: e.message } }
         Server.fire_event(ClientError.new(response), node)

--- a/lib/backbeat/workers/async_worker.rb
+++ b/lib/backbeat/workers/async_worker.rb
@@ -76,11 +76,6 @@ module Backbeat
       rescue DeserializeError => e
         error(status: :deserialize_node_error, node: node_data["node_id"], error: e, backtrace: e.backtrace)
         raise e
-      rescue NetworkError => e
-        Kernel.sleep(Config.options[:connection_error_wait])
-        if (node.reload.current_client_status != :complete)
-          handle_processing_error(e, event_class, node, options)
-        end
       rescue => e
         handle_processing_error(e, event_class, node, options)
       end

--- a/spec/unit/events_spec.rb
+++ b/spec/unit/events_spec.rb
@@ -168,9 +168,19 @@ describe Backbeat::Events do
         Backbeat::Events::StartNode.call(node)
       end
 
-      it "fires the ClientError event if the client call fails" do
+      it "fires the ClientError event if the client call fails with an HttpError" do
         allow(Backbeat::Client).to receive(:perform).with(node) { raise Backbeat::HttpError.new("Failed", {}) }
 
+        expect(Backbeat::Server).to receive(:fire_event).with(Backbeat::Events::ClientError, node)
+
+        Backbeat::Events::StartNode.call(node)
+      end
+
+      it "waits for ClientComplete event if the client call fails with a NetworkError" do
+        allow(Backbeat::Client).to receive(:perform).with(node) { raise Backbeat::NetworkError.new("Errno::ECONNRESET", {}) }
+        allow(Backbeat::Config).to receive(:options).and_return({connection_error_wait: 0.01})
+
+        expect(Kernel).to receive(:sleep).with(0.01)
         expect(Backbeat::Server).to receive(:fire_event).with(Backbeat::Events::ClientError, node)
 
         Backbeat::Events::StartNode.call(node)


### PR DESCRIPTION
Since the backbeat client can be called outside of `business_perform` in `async_worker` we are moving the error handling into `Events::StartNode`. This will also fix an issue around `NetworkError` not being caught in `Events::StartNode` and therefore never transitioning the nodes to be in errored state.